### PR TITLE
optional Function Name

### DIFF
--- a/ns-3/src/ndnSIM/ndn-cxx/src/data.hpp
+++ b/ns-3/src/ndnSIM/ndn-cxx/src/data.hpp
@@ -165,14 +165,12 @@ public:
    */
   //defined by konomu
   // 追加するとPublicKeyでセグフォ発生
-/*
+
   const Name&
   getFunction() const;
 
   void
   setFunction(const Name& name);
-*/
-
 
   const Name&
   getFullName() const;
@@ -331,7 +329,7 @@ protected:
 
 private:
   Name m_name;
-  //mutable Name m_functionName; by konomu
+  mutable Name m_functionName; //by konomu
   MetaInfo m_metaInfo;
   mutable Block m_content;
   Signature m_signature;
@@ -355,13 +353,12 @@ Data::getName() const
   return m_name;
 }
 //by konomu
-/*
+
 inline const Name&
 Data::getFunction() const
 {
 	return m_functionName;
 }
-*/
 
 inline const MetaInfo&
 Data::getMetaInfo() const


### PR DESCRIPTION
m_functionName is made optional in Data::wireEncode() and Data::wireDecode()